### PR TITLE
[add-allauth] Add support for django-allauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ A modern template for supercharging your Django project with [Vite](https://vite
   - PostgreSQL
   - SQLite (configured for production if selected)
 
+- **Authentication Options**
+
+  - django-allauth (optional)
+
 - **Development & Deployment**
   - Docker support (optional)
     - Development environment

--- a/copier.yml
+++ b/copier.yml
@@ -43,6 +43,11 @@ starter_kit:
   default: false
   when: "{{ frontend == 'react' and tailwind_css }}"
 
+allauth:
+  type: bool
+  help: Do you want to use django-allauth for authentication?
+  default: true
+
 _message_after_copy: |
   Your Django + Vite + Inertia project "{{ project_name }}" has been created successfully!
 

--- a/project/.gitignore
+++ b/project/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -9,10 +9,9 @@ dependencies = [
     "django>=5.1.4",
     "django-vite>=3.0.5",
     "inertia-django>=0.6.0",
-    {% if database == 'postgresql' %}
-    "psycopg>=3.2.3",
-    "psycopg-binary>=3.2.3",
-    {% endif %}
+    {% if database == 'postgresql' %}"psycopg>=3.2.3",
+    "psycopg-binary>=3.2.3",{% endif %}
+    {% if allauth %}"django-allauth>=65.11.2",{% endif %}
     "whitenoise>=6.8.2",
     "gunicorn>=23.0.0",
 ]

--- a/project/{{project_name}}/settings.py.jinja
+++ b/project/{{project_name}}/settings.py.jinja
@@ -36,9 +36,9 @@ DEBUG = env.bool("DEBUG", default=True)
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
 
+SITE_ID = 1
 
 # Application definition
-
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -46,8 +46,13 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     "django_vite",
     "inertia",
+    {% if allauth %}
+    "allauth",
+    "allauth.account",
+    {% endif %}
 ]
 
 MIDDLEWARE = [
@@ -59,6 +64,9 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    {% if allauth %}
+    "allauth.account.middleware.AccountMiddleware",
+    {% endif %}
     "inertia.middleware.InertiaMiddleware",
     "{{ project_name }}.middleware.DataShareMiddleware",
 ]
@@ -76,6 +84,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                
             ],
         },
     },
@@ -137,6 +146,20 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
+
+AUTHENTICATION_BACKENDS = [
+    # Needed to login by username in Django admin, regardless of `allauth`
+    "django.contrib.auth.backends.ModelBackend",
+    {% if allauth %}
+    # `allauth` specific authentication methods, such as login by email
+    "allauth.account.auth_backends.AuthenticationBackend",
+    {% endif %}
+]
+
+LOGIN_REDIRECT_URL = "/"
+{% if allauth %}
+ACCOUNT_EMAIL_VERIFICATION = "none"
+{% endif %}
 
 
 # Internationalization

--- a/project/{{project_name}}/urls.py.jinja
+++ b/project/{{project_name}}/urls.py.jinja
@@ -16,11 +16,12 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 from . import views
 
 urlpatterns = [
     path("", views.home, name="home"),
     path("admin/", admin.site.urls),
+    {% if allauth %}path("accounts/", include("allauth.urls")),{% endif %}
 ]


### PR DESCRIPTION
Users of the template can now decide if they wish to use django-allauth for setting up authentication as part of the template setup